### PR TITLE
Show raw plugin stdout/stderr in fullscreen view

### DIFF
--- a/services/saw_api/app/main.py
+++ b/services/saw_api/app/main.py
@@ -619,6 +619,8 @@ class PluginExecuteResponse(BaseModel):
     plugin_id: str
     outputs: dict[str, Any]
     logs: list[dict[str, Any]]
+    raw_stdout: str = ""
+    raw_stderr: str = ""
 
 
 class PluginForkRequest(BaseModel):
@@ -921,6 +923,8 @@ def plugins_execute(req: PluginExecuteRequest) -> PluginExecuteResponse:
             plugin_id=pid,
             outputs=r.get("outputs") or {},
             logs=r.get("logs") or [],
+            raw_stdout=str(r.get("raw_stdout") or ""),
+            raw_stderr=str(r.get("raw_stderr") or ""),
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"plugin_execute_failed: {e}")
@@ -1029,4 +1033,3 @@ class ServiceStopResponse(BaseModel):
 def api_stop_service(service_id: str) -> ServiceStopResponse:
     stopped, prior = stop_service(settings, service_id)
     return ServiceStopResponse(ok=True, stopped=bool(stopped), prior_status=str(prior))
-

--- a/services/saw_api/app/plugins_runtime.py
+++ b/services/saw_api/app/plugins_runtime.py
@@ -171,16 +171,18 @@ def execute_plugin(
 
     # plugin_runner prints JSON result on stdout even on failure.
     out: dict[str, Any] = {}
+    parsed_ok = False
     if stdout:
         try:
             parsed = json.loads(stdout)
             if isinstance(parsed, dict):
                 out = parsed
+                parsed_ok = True
         except Exception:
             out = {}
 
     # If the runner failed and did not provide a structured payload, raise with best details we have.
-    if p.returncode != 0 and not out:
+    if p.returncode != 0 and not parsed_ok:
         # stderr is often dominated by progress bars; show a tail snippet and point to log files.
         tail = (stderr or stdout)[-4000:]
         raise RuntimeError(
@@ -188,6 +190,7 @@ def execute_plugin(
             f"logs: {os.path.join(temp_run_dir, 'logs')}"
         )
 
+    out["raw_stdout"] = stdout
+    out["raw_stderr"] = stderr
+
     return out
-
-

--- a/src/components/ModuleFullscreenModal.tsx
+++ b/src/components/ModuleFullscreenModal.tsx
@@ -42,6 +42,8 @@ export function ModuleFullscreenModal() {
   const isLockedStock = Boolean(isWorkspacePlugin && plugin.locked && plugin.origin === 'stock')
   const lastRun = node.data.runtime?.exec?.last ?? null
   const running = node.data.status === 'running'
+  const rawStdout = lastRun?.rawStdout ?? ''
+  const rawStderr = lastRun?.rawStderr ?? ''
 
   return (
     <div className="fixed inset-0 z-[60] bg-black/70 p-4">
@@ -119,6 +121,27 @@ export function ModuleFullscreenModal() {
                           <pre className="max-h-[200px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
                             {JSON.stringify(lastRun.outputs ?? {}, null, 2)}
                           </pre>
+                          {(rawStdout || rawStderr) ? (
+                            <div className="space-y-2">
+                              <div className="text-[11px] font-semibold text-zinc-400">Raw Python output</div>
+                              {rawStdout ? (
+                                <div>
+                                  <div className="text-[11px] text-zinc-500">stdout</div>
+                                  <pre className="max-h-[160px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+                                    {rawStdout}
+                                  </pre>
+                                </div>
+                              ) : null}
+                              {rawStderr ? (
+                                <div>
+                                  <div className="text-[11px] text-zinc-500">stderr</div>
+                                  <pre className="max-h-[160px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-red-200">
+                                    {rawStderr}
+                                  </pre>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
                         </div>
                       ) : (
                         <div className="mt-2 text-[11px] text-zinc-500">No runs yet.</div>
@@ -255,5 +278,4 @@ export function ModuleFullscreenModal() {
     </div>
   )
 }
-
 

--- a/src/store/useSawStore.ts
+++ b/src/store/useSawStore.ts
@@ -876,7 +876,14 @@ const _useSawStore = create<SawState>((set, get) => ({
         }),
       })
       if (!r.ok) throw new Error(await r.text())
-      const j = (await r.json()) as { ok: boolean; outputs: any; logs?: any[]; error?: any }
+      const j = (await r.json()) as {
+        ok: boolean
+        outputs: any
+        logs?: any[]
+        raw_stdout?: string
+        raw_stderr?: string
+        error?: any
+      }
       const ok = Boolean(j?.ok)
       const logs = Array.isArray(j?.logs) ? j.logs : []
       const ranAt = Date.now()
@@ -891,7 +898,17 @@ const _useSawStore = create<SawState>((set, get) => ({
               status: ok ? 'idle' : 'error',
               runtime: {
                 ...(n.data.runtime ?? {}),
-                exec: { last: { ok, outputs: j?.outputs ?? {}, logs, error: j?.error ?? null, ranAt } },
+                exec: {
+                  last: {
+                    ok,
+                    outputs: j?.outputs ?? {},
+                    logs,
+                    rawStdout: j?.raw_stdout ?? '',
+                    rawStderr: j?.raw_stderr ?? '',
+                    error: j?.error ?? null,
+                    ranAt,
+                  },
+                },
               },
             },
           }
@@ -1202,5 +1219,4 @@ try {
 } catch {
   // ignore
 }
-
 

--- a/src/types/saw.ts
+++ b/src/types/saw.ts
@@ -78,6 +78,8 @@ export type ExecRuntime = {
     ok: boolean
     outputs: any
     logs: any[]
+    rawStdout?: string
+    rawStderr?: string
     error?: string | null
     ranAt: number
   } | null
@@ -104,5 +106,4 @@ export type PluginNodeData = {
 }
 
 export type PluginNode = Node<PluginNodeData, 'pluginNode'>
-
 


### PR DESCRIPTION
### Motivation
- Developers need to see the raw Python process output when a plugin is executed so debugging is easier than inspecting only the structured `outputs` or error summary.
- The plugin runner already persisted stdout/stderr to logs but did not surface the raw text to the API response or the frontend runtime state.
- The fullscreen module view shows manifest/wrapper and run controls, so it's the natural place to display raw stdout/stderr alongside the JSON outputs.

### Description
- Capture and return raw runner output by adding `raw_stdout`/`raw_stderr` to the execution payload in `execute_plugin` and include them in the `/plugins/execute` response model (`PluginExecuteResponse`).
- Expose the raw outputs to the frontend by storing `rawStdout`/`rawStderr` in the node exec runtime state via `runPluginNode` in `src/store/useSawStore.ts`.
- Add the new fields to the TypeScript types by updating `ExecRuntime` in `src/types/saw.ts`.
- Render the raw stdout/stderr text in the fullscreen module run panel in `ModuleFullscreenModal.tsx` when present.

### Testing
- Started the frontend dev server with `npm run dev` and Vite reported ready, indicating the frontend served successfully.
- Attempted a Playwright-based screenshot to validate UI rendering but the Chromium process crashed in this environment, so the visual test could not complete.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bdb7fac48328ab5af7c9c5ee9100)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds raw process output plumbing end-to-end for easier debugging.
> 
> - Backend: `plugins_runtime.execute_plugin` now always attaches `raw_stdout`/`raw_stderr` to the result and only raises on nonzero exit when JSON parsing fails; logs still persisted
> - API: `PluginExecuteResponse` extended with `raw_stdout`/`raw_stderr` and values returned by `/plugins/execute`
> - Frontend state: `runPluginNode` stores `rawStdout`/`rawStderr` in `exec.last`; `ExecRuntime` type updated
> - UI: `ModuleFullscreenModal` shows "Raw Python output" (stdout/stderr) alongside JSON `outputs` when available
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83d0e587343bda08d6b882191cc9654aec6bd2bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->