### PR TITLE
Add input editing for plugin runs and surface raw Python output

### DIFF
--- a/services/saw_api/app/main.py
+++ b/services/saw_api/app/main.py
@@ -619,6 +619,8 @@ class PluginExecuteResponse(BaseModel):
     plugin_id: str
     outputs: dict[str, Any]
     logs: list[dict[str, Any]]
+    raw_stdout: str = ""
+    raw_stderr: str = ""
 
 
 class PluginForkRequest(BaseModel):
@@ -921,6 +923,8 @@ def plugins_execute(req: PluginExecuteRequest) -> PluginExecuteResponse:
             plugin_id=pid,
             outputs=r.get("outputs") or {},
             logs=r.get("logs") or [],
+            raw_stdout=str(r.get("raw_stdout") or ""),
+            raw_stderr=str(r.get("raw_stderr") or ""),
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"plugin_execute_failed: {e}")
@@ -1029,4 +1033,3 @@ class ServiceStopResponse(BaseModel):
 def api_stop_service(service_id: str) -> ServiceStopResponse:
     stopped, prior = stop_service(settings, service_id)
     return ServiceStopResponse(ok=True, stopped=bool(stopped), prior_status=str(prior))
-

--- a/services/saw_api/app/plugins_runtime.py
+++ b/services/saw_api/app/plugins_runtime.py
@@ -171,16 +171,18 @@ def execute_plugin(
 
     # plugin_runner prints JSON result on stdout even on failure.
     out: dict[str, Any] = {}
+    parsed_ok = False
     if stdout:
         try:
             parsed = json.loads(stdout)
             if isinstance(parsed, dict):
                 out = parsed
+                parsed_ok = True
         except Exception:
             out = {}
 
     # If the runner failed and did not provide a structured payload, raise with best details we have.
-    if p.returncode != 0 and not out:
+    if p.returncode != 0 and not parsed_ok:
         # stderr is often dominated by progress bars; show a tail snippet and point to log files.
         tail = (stderr or stdout)[-4000:]
         raise RuntimeError(
@@ -188,6 +190,7 @@ def execute_plugin(
             f"logs: {os.path.join(temp_run_dir, 'logs')}"
         )
 
+    out["raw_stdout"] = stdout
+    out["raw_stderr"] = stderr
+
     return out
-
-

--- a/src/components/ModuleFullscreenModal.tsx
+++ b/src/components/ModuleFullscreenModal.tsx
@@ -7,6 +7,7 @@ import { SourceViewer } from './SourceViewer'
 import { IngestDirectoryModule } from './modules/IngestDirectoryModule'
 import { BouncingTextModule } from './modules/BouncingTextModule'
 import { ReadOnlyFileViewer } from './ReadOnlyFileViewer'
+import { NodeInputs } from './inspector/NodeInputs'
 import { NodeParameters } from './inspector/NodeParameters'
 
 export function ModuleFullscreenModal() {
@@ -42,6 +43,8 @@ export function ModuleFullscreenModal() {
   const isLockedStock = Boolean(isWorkspacePlugin && plugin.locked && plugin.origin === 'stock')
   const lastRun = node.data.runtime?.exec?.last ?? null
   const running = node.data.status === 'running'
+  const rawStdout = lastRun?.rawStdout ?? ''
+  const rawStderr = lastRun?.rawStderr ?? ''
 
   return (
     <div className="fixed inset-0 z-[60] bg-black/70 p-4">
@@ -68,6 +71,7 @@ export function ModuleFullscreenModal() {
             <Panel title="Module" className="min-h-0 overflow-hidden">
               <div className="h-full overflow-auto p-3">
                 <div className="space-y-3">
+                  <NodeInputs nodeId={node.id} />
                   <NodeParameters nodeId={node.id} />
 
                   {isWorkspacePlugin ? (
@@ -119,6 +123,27 @@ export function ModuleFullscreenModal() {
                           <pre className="max-h-[200px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
                             {JSON.stringify(lastRun.outputs ?? {}, null, 2)}
                           </pre>
+                          {(rawStdout || rawStderr) ? (
+                            <div className="space-y-2">
+                              <div className="text-[11px] font-semibold text-zinc-400">Raw Python output</div>
+                              {rawStdout ? (
+                                <div>
+                                  <div className="text-[11px] text-zinc-500">stdout</div>
+                                  <pre className="max-h-[160px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+                                    {rawStdout}
+                                  </pre>
+                                </div>
+                              ) : null}
+                              {rawStderr ? (
+                                <div>
+                                  <div className="text-[11px] text-zinc-500">stderr</div>
+                                  <pre className="max-h-[160px] overflow-auto whitespace-pre-wrap font-mono text-[11px] text-red-200">
+                                    {rawStderr}
+                                  </pre>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
                         </div>
                       ) : (
                         <div className="mt-2 text-[11px] text-zinc-500">No runs yet.</div>
@@ -255,5 +280,3 @@ export function ModuleFullscreenModal() {
     </div>
   )
 }
-
-

--- a/src/components/inspector/NodeInputs.tsx
+++ b/src/components/inspector/NodeInputs.tsx
@@ -1,0 +1,61 @@
+import { useSawStore } from '../../store/useSawStore'
+
+function inputKind(inputType: string) {
+  const t = inputType.toLowerCase()
+  if (['number', 'float', 'int', 'integer'].includes(t)) return 'number'
+  return 'text'
+}
+
+export function NodeInputs(props: { nodeId: string; title?: string }) {
+  const node = useSawStore((s) => s.nodes.find((n) => n.id === props.nodeId) ?? null)
+  const pluginCatalog = useSawStore((s) => s.pluginCatalog)
+  const updateNodeInput = useSawStore((s) => s.updateNodeInput)
+
+  if (!node) return null
+  const plugin = pluginCatalog.find((p) => p.id === node.data.pluginId) ?? null
+  if (!plugin) return null
+
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold tracking-wide text-zinc-200">{props.title ?? 'Inputs'}</div>
+      <div className="space-y-2">
+        {plugin.inputs.length === 0 && <div className="text-sm text-zinc-500">No editable inputs.</div>}
+        {plugin.inputs.map((input) => {
+          const v = node.data.inputs?.[input.id]
+          const kind = inputKind(input.type)
+          const label = (
+            <div className="text-xs text-zinc-400">
+              {input.name} <span className="text-zinc-600">({input.type})</span>
+            </div>
+          )
+
+          if (kind === 'number') {
+            return (
+              <div key={input.id} className="rounded-md border border-zinc-800 bg-zinc-950/40 p-2">
+                {label}
+                <input
+                  type="number"
+                  value={typeof v === 'number' ? v : Number(v ?? '')}
+                  step="any"
+                  onChange={(e) => updateNodeInput(node.id, input.id, Number(e.target.value))}
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-700"
+                />
+              </div>
+            )
+          }
+
+          return (
+            <div key={input.id} className="rounded-md border border-zinc-800 bg-zinc-950/40 p-2">
+              {label}
+              <input
+                value={String(v ?? '')}
+                onChange={(e) => updateNodeInput(node.id, input.id, e.target.value)}
+                className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-700"
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/store/useSawStore.ts
+++ b/src/store/useSawStore.ts
@@ -71,6 +71,7 @@ type SawState = {
   isValidConnection: (c: Connection) => boolean
   tryAddEdge: (c: Connection) => void
   updateNodeParam: (nodeId: string, paramId: string, value: string | number) => void
+  updateNodeInput: (nodeId: string, inputId: string, value: string | number) => void
   openFullscreen: (nodeId: string) => void
   closeFullscreen: () => void
   refreshAiStatus: () => Promise<void>
@@ -136,6 +137,7 @@ function makeNodeData(catalog: PluginDefinition[], pluginId: string): PluginNode
       pluginId,
       title: pluginId,
       status: 'error',
+      inputs: {},
       params: {},
       portTypes: {},
       code: `# Unknown plugin: ${pluginId}`,
@@ -146,6 +148,8 @@ function makeNodeData(catalog: PluginDefinition[], pluginId: string): PluginNode
   }
   const params: Record<string, string | number> = {}
   for (const def of p.parameters) params[def.id] = def.default
+  const inputs: Record<string, string | number> = {}
+  for (const input of p.inputs) inputs[input.id] = ''
 
   const portTypes: Record<string, string> = {}
   for (const input of p.inputs) portTypes[`in:${input.id}`] = input.type
@@ -159,6 +163,7 @@ function makeNodeData(catalog: PluginDefinition[], pluginId: string): PluginNode
     pluginId,
     title: p.name,
     status: 'idle',
+    inputs,
     params,
     portTypes,
     code,
@@ -486,6 +491,13 @@ const _useSawStore = create<SawState>((set, get) => ({
     if (node?.data.pluginId === 'audio_lowpass' && paramId === 'cutoff_hz') {
       void get().recomputeLowpass(nodeId)
     }
+  },
+  updateNodeInput: (nodeId, inputId, value) => {
+    set((s) => ({
+      nodes: s.nodes.map((n) =>
+        n.id === nodeId ? { ...n, data: { ...n.data, inputs: { ...n.data.inputs, [inputId]: value } } } : n,
+      ),
+    }))
   },
 
   openFullscreen: (nodeId) => set({ fullscreen: { open: true, nodeId } }),
@@ -859,6 +871,9 @@ const _useSawStore = create<SawState>((set, get) => ({
     const node = get().nodes.find((n) => n.id === nodeId) ?? null
     if (!node) return { ok: false, error: 'missing_node' }
     const pluginId = node.data.pluginId
+    const inputPayload = Object.fromEntries(
+      Object.entries(node.data.inputs ?? {}).map(([key, value]) => [key, { data: value }]),
+    )
 
     set((s) => ({
       nodes: s.nodes.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, status: 'running' } } : n)),
@@ -871,12 +886,19 @@ const _useSawStore = create<SawState>((set, get) => ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           plugin_id: pluginId,
-          inputs: {},
+          inputs: inputPayload,
           params: node.data.params ?? {},
         }),
       })
       if (!r.ok) throw new Error(await r.text())
-      const j = (await r.json()) as { ok: boolean; outputs: any; logs?: any[]; error?: any }
+      const j = (await r.json()) as {
+        ok: boolean
+        outputs: any
+        logs?: any[]
+        raw_stdout?: string
+        raw_stderr?: string
+        error?: any
+      }
       const ok = Boolean(j?.ok)
       const logs = Array.isArray(j?.logs) ? j.logs : []
       const ranAt = Date.now()
@@ -891,7 +913,17 @@ const _useSawStore = create<SawState>((set, get) => ({
               status: ok ? 'idle' : 'error',
               runtime: {
                 ...(n.data.runtime ?? {}),
-                exec: { last: { ok, outputs: j?.outputs ?? {}, logs, error: j?.error ?? null, ranAt } },
+                exec: {
+                  last: {
+                    ok,
+                    outputs: j?.outputs ?? {},
+                    logs,
+                    rawStdout: j?.raw_stdout ?? '',
+                    rawStderr: j?.raw_stderr ?? '',
+                    error: j?.error ?? null,
+                    ranAt,
+                  },
+                },
               },
             },
           }
@@ -1202,5 +1234,3 @@ try {
 } catch {
   // ignore
 }
-
-

--- a/src/types/saw.ts
+++ b/src/types/saw.ts
@@ -78,6 +78,8 @@ export type ExecRuntime = {
     ok: boolean
     outputs: any
     logs: any[]
+    rawStdout?: string
+    rawStderr?: string
     error?: string | null
     ranAt: number
   } | null
@@ -87,6 +89,7 @@ export type PluginNodeData = {
   pluginId: string
   title: string
   status: NodeStatus
+  inputs: Record<string, string | number>
   params: Record<string, string | number>
   /**
    * handleId -> type
@@ -104,5 +107,3 @@ export type PluginNodeData = {
 }
 
 export type PluginNode = Node<PluginNodeData, 'pluginNode'>
-
-


### PR DESCRIPTION
### Motivation
- Workspace plugins (e.g. the plugin generator) require user-supplied inputs like `repo_url`, `user_request`, `code_path`, and `code_snippet`, but there was no UI to set or persist those per-node values.  
- Plugin execution should forward node input values as the structured `inputs` payload so wrappers receive the expected context.  
- Raw runner stdout/stderr are valuable for debugging and should be returned from the runner and shown in the fullscreen module run panel.  
- Initialize node input state so new workspace plugin nodes start with editable input fields rather than requiring manual payload construction.

### Description
- Added a new inspector component `src/components/inspector/NodeInputs.tsx` and included it in `src/components/ModuleFullscreenModal.tsx` to render editable input fields for workspace plugins.  
- Extended the node model with an `inputs` map in `src/types/saw.ts` and initialize it in `makeNodeData` inside `src/store/useSawStore.ts`.  
- Implemented `updateNodeInput` and wired input values into `runPluginNode` so the frontend sends `inputs` (e.g. `{ key: { data: value } }`) to the execution API in `src/store/useSawStore.ts`.  
- Plumbed raw runner output through the backend by returning `raw_stdout`/`raw_stderr` from `execute_plugin` in `services/saw_api/app/plugins_runtime.py`, exposing them in the `/plugins/execute` response model in `services/saw_api/app/main.py`, and rendering the raw text in the fullscreen panel; also added `rawStdout`/`rawStderr` to `ExecRuntime` in `src/types/saw.ts`.

### Testing
- Started the frontend dev server with `npm run dev` and Vite reported ready, indicating the UI served successfully.  
- Ran an automated Playwright snapshot that completed and produced a screenshot artifact of the fullscreen view with the new Inputs section.  
- During the dev run the frontend attempted to fetch `/plugins/list` and encountered an automated proxy error (`ECONNREFUSED 127.0.0.1:5127`) because the backend service was not running in that session.  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bdb7fac48328ab5af7c9c5ee9100)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-node input editing and plumbs raw runner output end-to-end for easier debugging.
> 
> - Adds `NodeInputs` inspector and integrates it in `ModuleFullscreenModal`; extends node model with `data.inputs`, initializes from plugin `inputs`, and adds `updateNodeInput`
> - `runPluginNode` now sends structured `inputs` (`{ key: { data: value } }`) and persists `rawStdout`/`rawStderr` in `runtime.exec.last`
> - Extends types: `ExecRuntime` includes `rawStdout`/`rawStderr`; `PluginNodeData` gains `inputs`
> - Backend: `execute_plugin` writes logs, returns `raw_stdout`/`raw_stderr`, and only throws on nonzero rc when JSON wasn’t parsed; API `PluginExecuteResponse` includes these fields and forwards them
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a29c75547b31d4c24fb458f107f3a66d492c999c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->