### PR TITLE
Simplify plugin generator params (remove inputs, add optional repo param)

### DIFF
--- a/saw-workspace/plugins/saw.plugin.file/plugin.yaml
+++ b/saw-workspace/plugins/saw.plugin.file/plugin.yaml
@@ -8,19 +8,6 @@ entrypoint:
   callable: "main"
 environment:
   python: ">=3.11,<3.13"
-inputs:
-  repo_url:
-    type: "string"
-    description: "Git repo URL to clone into saw-workspace/sources (optional)."
-  user_request:
-    type: "text"
-    description: "User description of desired plugin behavior (optional)."
-  code_path:
-    type: "path"
-    description: "Workspace-relative path to code or notebook (optional)."
-  code_snippet:
-    type: "text"
-    description: "Inline code snippet to wrap (optional)."
 params:
   plugin_name:
     type: "string"
@@ -30,6 +17,10 @@ params:
     type: "string"
     default: ""
     ui: { label: "Plugin description" }
+  repo_url:
+    type: "string"
+    default: ""
+    ui: { label: "Repo URL (optional)" }
 outputs:
   result:
     type: "object"


### PR DESCRIPTION
### Motivation
- Hide the UI "Inputs" section by removing the old `inputs:` declarations from the plugin manifest. 
- Keep a minimal set of plugin parameters so the generator remains configurable with simple fields. 
- Expose a single optional repository field as a `param` so it appears with an explicit optional label in the UI. 
- Preserve the plugin `entrypoint` and declared `outputs` so runtime behavior is unchanged.

### Description
- Removed the `inputs:` block for `repo_url`, `user_request`, `code_path`, and `code_snippet` in `saw-workspace/plugins/saw.plugin.file/plugin.yaml`.
- Kept `params` for `plugin_name` and `plugin_description` intact and unchanged.
- Added a `repo_url` entry under `params` with `default: ""` and `ui: { label: "Repo URL (optional)" }` to mark it explicitely optional.
- Left the `entrypoint` (`wrapper.py` / `main`) and the `outputs` (`result`) unchanged.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965cdaf69bc832892308b61735184b8)