### PR TITLE
Add Utilities menu and Streamlit external-tab utility plugins

### DIFF
--- a/saw-workspace/human-context/Directory.md
+++ b/saw-workspace/human-context/Directory.md
@@ -62,7 +62,11 @@ Scientific AI Workstation
                runs_services.sql 
             tests
                 test_env_hashing.py
-                test_port_allocation.py
+               test_port_allocation.py
+
+Recent updates
+    - Added utility plugins that launch Streamlit apps in new browser tabs (file browser, DB explorer, RAG explorer, API health explorer).
+    - Top bar now includes a Utilities menu sourced from plugin manifests.
 
 ###################################################################
 

--- a/saw-workspace/human-context/PLUGIN_SCHEMA.md
+++ b/saw-workspace/human-context/PLUGIN_SCHEMA.md
@@ -38,6 +38,7 @@ Recommended keys:
 
 - `ui: { mode: schema, schema_file: ui/declarative_ui.yaml, bundle_file: ui/ui.bundle.js, sandbox: true }`
 - `meta:` — optional descriptive metadata (human + machine descriptions)
+- `utility:` — optional utility launcher metadata (e.g., `kind: external_tab`, `menu_path`, `launch.expect.output_path`)
 
 ## UI (Declarative UI)
 

--- a/saw-workspace/machine-context/START_HERE.md
+++ b/saw-workspace/machine-context/START_HERE.md
@@ -36,3 +36,7 @@ Evidence kinds are standardized as:
 
 Until that exists, `attestation/default_probes.v1.json` is the source-of-truth for which probes/files must be included.
 
+## Recent updates
+
+- Added utility plugin support for launching Streamlit apps in new browser tabs (file browser, DB explorer, RAG explorer, API health explorer).
+- Frontend now surfaces utilities from plugin manifests in the top bar.

--- a/saw-workspace/machine-specs/utility_external_tabs_spec.yaml
+++ b/saw-workspace/machine-specs/utility_external_tabs_spec.yaml
@@ -1,0 +1,136 @@
+spec:
+  id: MR-SAW-Utilities-ExternalTabs-v0.1
+  title: Utilities plugins that launch external browser tabs (Streamlit + file/db explorers)
+  status: proposal
+  intent:
+    - "Allow certain plugins to launch a separate browser tab for utility UIs (Streamlit or HTTP)."
+    - "Keep plugin.yaml as the single source of truth for discoverability + menu placement."
+    - "Minimize future debt by reusing existing plugin execution + catalog flow."
+
+existing_system_context:
+  plugin_manifest:
+    file: services/saw_api/app/plugins_runtime.py
+    class: PluginManifest
+    ui_spec: PluginUiSpec
+  frontend_catalog:
+    types: src/types/saw.ts (PluginDefinition, PluginUiConfig)
+    loader: src/plugins/workspace.ts (fetchWorkspacePlugins)
+
+proposal:
+  manifest_extension:
+    add_field_to_plugin_manifest: utility
+    purpose: "Declare a plugin as a top-level utility and describe how to launch it."
+    yaml_shape:
+      utility:
+        kind: "external_tab"  # future: "inline_panel" | "modal" | "external_tab"
+        label: "Database Explorer"
+        description: "Explore data via Streamlit."
+        menu_path: ["Utilities", "Data"]
+        icon: "database"
+        launch:
+          action: "run_plugin"   # uses existing /api/plugins/{plugin_id}/run
+          open_target: "new_tab" # browser tab
+          expect:
+            type: "url"
+          output_path: "result.data.url"  # JSONPath-ish pointer into plugin outputs
+          app:
+            kind: "streamlit"    # "streamlit" | "http"
+            healthcheck: "/_stcore/health"
+          session:
+            allow_multiple: true
+            reuse_when_open: true
+
+  backend_runtime:
+    strategy:
+      - "Keep plugin execution unchanged; utilities are standard plugins."
+      - "Streamlit apps are started inside wrapper.py and return a URL in outputs."
+      - "Optional: add a tiny helper in SAW API to pick free ports (or keep in wrapper)."
+    wrapper_contract:
+      output_example:
+        result:
+          url: "http://127.0.0.1:8510"
+          status: "started"
+
+  frontend_integration:
+    menu_bar:
+      add_top_menu: true
+      utilities_group:
+        source: "plugin catalog entries with utility.kind == 'external_tab'"
+        click_behavior:
+          - "Call /api/plugins/{plugin_id}/run with defaults."
+          - "Read output_path for URL."
+          - "Open in new browser tab via window.open(url, '_blank')."
+    error_states:
+      - "If URL missing, show toast with stdout/stderr in inspector."
+      - "If server not reachable, show retry + open logs."
+
+  machine_readable_examples:
+    file_browser_plugin_yaml_snippet:
+      id: "saw.utility.file_browser"
+      name: "File Browser (Utility)"
+      version: "0.1.0"
+      description: "Browse workspace files in a separate tab."
+      category_path: "utilities"
+      entrypoint:
+        file: "wrapper.py"
+        callable: "main"
+      environment:
+        python: ">=3.11,<3.13"
+        pip: ["streamlit"]
+      ui:
+        mode: "schema"
+      utility:
+        kind: "external_tab"
+        label: "File Browser"
+        menu_path: ["Utilities", "Files"]
+        icon: "folder"
+        launch:
+          action: "run_plugin"
+          open_target: "new_tab"
+          expect:
+            type: "url"
+            output_path: "result.data.url"
+          app:
+            kind: "streamlit"
+            healthcheck: "/_stcore/health"
+          session:
+            allow_multiple: true
+            reuse_when_open: true
+
+    db_browser_plugin_yaml_snippet:
+      id: "saw.utility.db_browser"
+      name: "Database Browser (Utility)"
+      version: "0.1.0"
+      description: "Explore database tables via Streamlit."
+      category_path: "utilities"
+      entrypoint:
+        file: "wrapper.py"
+        callable: "main"
+      environment:
+        python: ">=3.11,<3.13"
+        pip: ["streamlit", "sqlalchemy"]
+      ui:
+        mode: "schema"
+      utility:
+        kind: "external_tab"
+        label: "Database Explorer"
+        menu_path: ["Utilities", "Data"]
+        icon: "database"
+        launch:
+          action: "run_plugin"
+          open_target: "new_tab"
+          expect:
+            type: "url"
+            output_path: "result.data.url"
+          app:
+            kind: "streamlit"
+            healthcheck: "/_stcore/health"
+          session:
+            allow_multiple: true
+            reuse_when_open: true
+
+acceptance_criteria:
+  - "A plugin manifest can declare utility.kind=external_tab and a launch spec."
+  - "Utilities appear in a top menu and open a new browser tab."
+  - "Streamlit-based utilities return a URL in plugin outputs and the UI opens it."
+  - "No change to existing plugin execution semantics or UI schema/bundle modes."

--- a/saw-workspace/plugins/saw.utility.api_health_explorer/README.md
+++ b/saw-workspace/plugins/saw.utility.api_health_explorer/README.md
@@ -1,0 +1,7 @@
+# saw.utility.api_health_explorer
+
+Utility plugin that launches a Streamlit API explorer in a new browser tab.
+
+## Notes
+- Reads `saw-workspace/machine-context/api_endpoints.json` for endpoint metadata.
+- Stores the last running port in `.saw/utilities/saw.utility.api_health_explorer.json` for reuse.

--- a/saw-workspace/plugins/saw.utility.api_health_explorer/plugin.yaml
+++ b/saw-workspace/plugins/saw.utility.api_health_explorer/plugin.yaml
@@ -1,0 +1,57 @@
+id: "saw.utility.api_health_explorer"
+name: "API Health Explorer (Utility)"
+version: "0.1.0"
+description: "Browse SAW API endpoints and run quick health queries in a Streamlit tab."
+category_path: "utilities"
+meta:
+  human_description: "Launch a Streamlit API explorer in a new tab."
+  machine_description: "Utility plugin that starts a Streamlit API explorer and returns a URL."
+  tags: ["utility", "streamlit", "api"]
+entrypoint:
+  file: "wrapper.py"
+  callable: "main"
+environment:
+  python: ">=3.11,<3.13"
+  pip: ["streamlit", "requests"]
+inputs: {}
+params:
+  api_url:
+    type: "string"
+    default: ""
+    ui: { label: "SAW API URL (optional)" }
+outputs:
+  result:
+    type: "object"
+execution:
+  deterministic: false
+  cacheable: false
+side_effects:
+  network: "allowed"
+  disk: "read_only"
+  subprocess: "allowed"
+resources:
+  gpu: "forbidden"
+  threads: 1
+ui:
+  mode: "schema"
+  schema_file: "ui/declarative_ui.yaml"
+  bundle_file: "ui/ui.bundle.js"
+  sandbox: true
+utility:
+  kind: "external_tab"
+  label: "API Health Explorer"
+  description: "Inspect API endpoints and run quick health queries."
+  menu_path: ["Utilities", "APIs"]
+  icon: "pulse"
+  launch:
+    action: "run_plugin"
+    open_target: "new_tab"
+    expect:
+      type: "url"
+      output_path: "result.data.url"
+    app:
+      kind: "streamlit"
+      healthcheck: "/_stcore/health"
+    session:
+      allow_multiple: true
+      reuse_when_open: true

--- a/saw-workspace/plugins/saw.utility.api_health_explorer/streamlit_app.py
+++ b/saw-workspace/plugins/saw.utility.api_health_explorer/streamlit_app.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+import streamlit as st
+
+
+def _workspace_root() -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or Path.cwd()).resolve()
+
+
+def _api_url() -> str:
+    return os.environ.get("SAW_API_URL") or "http://127.0.0.1:5127"
+
+
+def _load_endpoints() -> dict[str, Any]:
+    root = _workspace_root()
+    path = root / "machine-context" / "api_endpoints.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+st.set_page_config(page_title="SAW API Health Explorer", layout="wide")
+st.title("API Health Explorer")
+
+api_url = st.sidebar.text_input("SAW API URL", value=_api_url())
+endpoints_doc = _load_endpoints()
+services = endpoints_doc.get("services") or []
+
+if not services:
+    st.warning("No API endpoints found in machine-context/api_endpoints.json")
+    st.stop()
+
+service_ids = [s.get("id") for s in services]
+service_id = st.selectbox("Service", options=service_ids, index=0)
+service = next((s for s in services if s.get("id") == service_id), {})
+
+st.caption(service.get("description") or "")
+
+query = st.text_input("Filter endpoints")
+endpoints = service.get("endpoints") or []
+if query:
+    endpoints = [e for e in endpoints if query.lower() in (e.get("path") or "").lower()]
+
+selected = st.selectbox(
+    "Endpoint",
+    options=endpoints,
+    format_func=lambda e: f"{e.get('method')} {e.get('path')}",
+)
+
+method = selected.get("method") or "GET"
+path = selected.get("path") or ""
+browser_path = selected.get("browser_path") or path
+
+st.markdown(f"**Description:** {selected.get('description') or '—'}")
+
+col1, col2 = st.columns(2)
+with col1:
+    params_json = st.text_area("Query params (JSON)", value="{}", height=120)
+with col2:
+    body_json = st.text_area("JSON body", value="{}", height=120)
+
+if st.button("Send request"):
+    try:
+        params = json.loads(params_json or "{}")
+        body = json.loads(body_json or "{}")
+    except Exception as exc:
+        st.error(f"Invalid JSON: {exc}")
+        st.stop()
+
+    url = api_url.rstrip("/") + path
+    try:
+        resp = requests.request(method=method, url=url, params=params, json=body, timeout=30)
+        st.write(f"Status: {resp.status_code}")
+        content_type = resp.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            st.json(resp.json())
+        else:
+            st.text(resp.text)
+    except Exception as exc:
+        st.error(f"Request failed: {exc}")
+
+st.markdown("---")
+
+st.subheader("Quick links")
+link_base = api_url.rstrip("/")
+if browser_path:
+    st.markdown(f"[Open in browser]({browser_path})")
+    st.code(f"curl -X {method} '{link_base}{path}'", language="bash")

--- a/saw-workspace/plugins/saw.utility.api_health_explorer/ui/declarative_ui.yaml
+++ b/saw-workspace/plugins/saw.utility.api_health_explorer/ui/declarative_ui.yaml
@@ -1,0 +1,10 @@
+version: 1
+sections:
+  - type: builtin
+    component: node_inputs
+  - type: builtin
+    component: node_parameters
+  - type: builtin
+    component: run_panel
+  - type: builtin
+    component: plugin_description

--- a/saw-workspace/plugins/saw.utility.api_health_explorer/wrapper.py
+++ b/saw-workspace/plugins/saw.utility.api_health_explorer/wrapper.py
@@ -1,0 +1,119 @@
+"""SAW Utility: Streamlit API Health Explorer."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _workspace_root(plugin_dir: Path) -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or plugin_dir.parents[2]).resolve()
+
+
+def _choose_free_port(host: str, port_range: tuple[int, int]) -> int:
+    start, end = port_range
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind((host, port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No free port found in range {start}-{end}")
+
+
+def _healthcheck(url: str, timeout_s: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def _state_path(workspace_root: Path, plugin_id: str) -> Path:
+    return workspace_root / ".saw" / "utilities" / f"{plugin_id}.json"
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_state(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _launch_streamlit(app_file: Path, host: str, port: int, env: dict) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_file),
+        "--server.headless",
+        "true",
+        "--server.address",
+        host,
+        "--server.port",
+        str(port),
+        "--server.fileWatcherType",
+        "none",
+    ]
+    subprocess.Popen(
+        cmd,
+        cwd=str(app_file.parent),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def main(inputs: dict, params: dict, context) -> dict:
+    plugin_dir = Path(__file__).resolve().parent
+    workspace_root = _workspace_root(plugin_dir)
+    host = "127.0.0.1"
+    port_range = (8780, 8869)
+
+    params = params or {}
+    api_url = str(params.get("api_url") or "").strip() or os.environ.get("SAW_API_URL") or "http://127.0.0.1:5127"
+
+    state_path = _state_path(workspace_root, "saw.utility.api_health_explorer")
+    state = _load_state(state_path)
+    url = str(state.get("url") or "")
+
+    if url and _healthcheck(url + "/_stcore/health"):
+        context.log("info", "api_health_explorer:reuse", url=url)
+    else:
+        port = _choose_free_port(host, port_range)
+        url = f"http://{host}:{port}"
+        env = dict(os.environ)
+        env["SAW_WORKSPACE_ROOT"] = str(workspace_root)
+        env["SAW_API_URL"] = api_url
+
+        app_file = plugin_dir / "streamlit_app.py"
+        _launch_streamlit(app_file, host, port, env)
+
+        time.sleep(0.2)
+        _save_state(state_path, {"url": url, "port": port, "api_url": api_url})
+        context.log("info", "api_health_explorer:launched", url=url, port=port, api_url=api_url)
+
+    return {
+        "result": {
+            "data": {
+                "url": url,
+            },
+            "metadata": {},
+        }
+    }

--- a/saw-workspace/plugins/saw.utility.db_browser/README.md
+++ b/saw-workspace/plugins/saw.utility.db_browser/README.md
@@ -1,0 +1,7 @@
+# saw.utility.db_browser
+
+Utility plugin that launches a Streamlit database explorer in a new browser tab.
+
+## Notes
+- Uses `SAW_DB_URL` (or the default SAW DB URL) to connect.
+- Stores the last running port in `.saw/utilities/saw.utility.db_browser.json` for reuse.

--- a/saw-workspace/plugins/saw.utility.db_browser/plugin.yaml
+++ b/saw-workspace/plugins/saw.utility.db_browser/plugin.yaml
@@ -1,0 +1,57 @@
+id: "saw.utility.db_browser"
+name: "Database Browser (Utility)"
+version: "0.1.0"
+description: "Explore the SAW Postgres database in a separate Streamlit tab."
+category_path: "utilities"
+meta:
+  human_description: "Launch a Streamlit database explorer in a new tab."
+  machine_description: "Utility plugin that starts a Streamlit DB explorer and returns a URL."
+  tags: ["utility", "streamlit", "database"]
+entrypoint:
+  file: "wrapper.py"
+  callable: "main"
+environment:
+  python: ">=3.11,<3.13"
+  pip: ["streamlit", "psycopg", "pandas"]
+inputs: {}
+params:
+  db_url:
+    type: "string"
+    default: ""
+    ui: { label: "Database URL (optional)" }
+outputs:
+  result:
+    type: "object"
+execution:
+  deterministic: false
+  cacheable: false
+side_effects:
+  network: "allowed"
+  disk: "read_only"
+  subprocess: "allowed"
+resources:
+  gpu: "forbidden"
+  threads: 1
+ui:
+  mode: "schema"
+  schema_file: "ui/declarative_ui.yaml"
+  bundle_file: "ui/ui.bundle.js"
+  sandbox: true
+utility:
+  kind: "external_tab"
+  label: "Database Explorer"
+  description: "Explore the SAW Postgres database in a new tab."
+  menu_path: ["Utilities", "Data"]
+  icon: "database"
+  launch:
+    action: "run_plugin"
+    open_target: "new_tab"
+    expect:
+      type: "url"
+      output_path: "result.data.url"
+    app:
+      kind: "streamlit"
+      healthcheck: "/_stcore/health"
+    session:
+      allow_multiple: true
+      reuse_when_open: true

--- a/saw-workspace/plugins/saw.utility.db_browser/streamlit_app.py
+++ b/saw-workspace/plugins/saw.utility.db_browser/streamlit_app.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pandas as pd
+import psycopg
+import streamlit as st
+
+
+def _default_db_url() -> str:
+    return os.environ.get("SAW_DB_URL") or "postgresql://saw_app:saw_app@127.0.0.1:54329/saw"
+
+
+def _fetch_tables(conn: psycopg.Connection[Any]) -> list[tuple[str, str]]:
+    rows = conn.execute(
+        """
+        SELECT table_schema, table_name
+        FROM information_schema.tables
+        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+        ORDER BY table_schema, table_name
+        """
+    ).fetchall()
+    return [(str(r[0]), str(r[1])) for r in rows]
+
+
+def _fetch_columns(conn: psycopg.Connection[Any], schema: str, table: str) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s
+        ORDER BY ordinal_position
+        """,
+        (schema, table),
+    ).fetchall()
+    return [str(r[0]) for r in rows]
+
+
+st.set_page_config(page_title="SAW Database Browser", layout="wide")
+
+st.title("Database Browser")
+
+with st.sidebar:
+    st.header("Connection")
+    db_url = st.text_input("Database URL", value=_default_db_url())
+    row_limit = st.number_input("Row limit", min_value=1, max_value=1000, value=100, step=10)
+
+if not db_url:
+    st.warning("Provide a database URL to continue.")
+    st.stop()
+
+try:
+    conn = psycopg.connect(db_url)
+except Exception as exc:
+    st.error(f"Connection failed: {exc}")
+    st.stop()
+
+with conn:
+    tables = _fetch_tables(conn)
+
+if not tables:
+    st.info("No tables found.")
+    st.stop()
+
+schema_table = st.selectbox(
+    "Select table",
+    options=tables,
+    format_func=lambda t: f"{t[0]}.{t[1]}",
+)
+
+schema, table = schema_table
+
+with conn:
+    columns = _fetch_columns(conn, schema, table)
+
+st.caption(f"Columns: {', '.join(columns)}")
+
+query = st.text_area(
+    "Optional SQL query (read-only)",
+    value=f"SELECT * FROM {schema}.{table} LIMIT {int(row_limit)}",
+    height=120,
+)
+
+if st.button("Run query"):
+    try:
+        df = pd.read_sql_query(query, conn)
+        st.dataframe(df, use_container_width=True)
+    except Exception as exc:
+        st.error(f"Query failed: {exc}")
+
+st.markdown("---")
+st.subheader("Table preview")
+try:
+    preview_df = pd.read_sql_query(
+        f"SELECT * FROM {schema}.{table} LIMIT {int(row_limit)}",
+        conn,
+    )
+    st.dataframe(preview_df, use_container_width=True)
+except Exception as exc:
+    st.error(f"Preview failed: {exc}")

--- a/saw-workspace/plugins/saw.utility.db_browser/ui/declarative_ui.yaml
+++ b/saw-workspace/plugins/saw.utility.db_browser/ui/declarative_ui.yaml
@@ -1,0 +1,10 @@
+version: 1
+sections:
+  - type: builtin
+    component: node_inputs
+  - type: builtin
+    component: node_parameters
+  - type: builtin
+    component: run_panel
+  - type: builtin
+    component: plugin_description

--- a/saw-workspace/plugins/saw.utility.db_browser/wrapper.py
+++ b/saw-workspace/plugins/saw.utility.db_browser/wrapper.py
@@ -1,0 +1,121 @@
+"""SAW Utility: Streamlit Database Browser."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _workspace_root(plugin_dir: Path) -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or plugin_dir.parents[2]).resolve()
+
+
+def _choose_free_port(host: str, port_range: tuple[int, int]) -> int:
+    start, end = port_range
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind((host, port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No free port found in range {start}-{end}")
+
+
+def _healthcheck(url: str, timeout_s: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def _state_path(workspace_root: Path, plugin_id: str) -> Path:
+    return workspace_root / ".saw" / "utilities" / f"{plugin_id}.json"
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_state(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _launch_streamlit(app_file: Path, host: str, port: int, env: dict) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_file),
+        "--server.headless",
+        "true",
+        "--server.address",
+        host,
+        "--server.port",
+        str(port),
+        "--server.fileWatcherType",
+        "none",
+    ]
+    subprocess.Popen(
+        cmd,
+        cwd=str(app_file.parent),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def main(inputs: dict, params: dict, context) -> dict:
+    plugin_dir = Path(__file__).resolve().parent
+    workspace_root = _workspace_root(plugin_dir)
+    host = "127.0.0.1"
+    port_range = (8600, 8689)
+
+    params = params or {}
+    db_url = str(params.get("db_url") or "").strip()
+
+    state_path = _state_path(workspace_root, "saw.utility.db_browser")
+    state = _load_state(state_path)
+    url = str(state.get("url") or "")
+
+    if url and _healthcheck(url + "/_stcore/health"):
+        context.log("info", "db_browser:reuse", url=url)
+    else:
+        port = _choose_free_port(host, port_range)
+        url = f"http://{host}:{port}"
+        env = dict(os.environ)
+        env["SAW_WORKSPACE_ROOT"] = str(workspace_root)
+        if db_url:
+            env["SAW_DB_URL"] = db_url
+        env.setdefault("SAW_DB_URL", "postgresql://saw_app:saw_app@127.0.0.1:54329/saw")
+
+        app_file = plugin_dir / "streamlit_app.py"
+        _launch_streamlit(app_file, host, port, env)
+
+        time.sleep(0.2)
+        _save_state(state_path, {"url": url, "port": port})
+        context.log("info", "db_browser:launched", url=url, port=port)
+
+    return {
+        "result": {
+            "data": {
+                "url": url,
+            },
+            "metadata": {},
+        }
+    }

--- a/saw-workspace/plugins/saw.utility.file_browser/README.md
+++ b/saw-workspace/plugins/saw.utility.file_browser/README.md
@@ -1,0 +1,7 @@
+# saw.utility.file_browser
+
+Utility plugin that launches a Streamlit file browser in a new browser tab.
+
+## Notes
+- Uses `SAW_WORKSPACE_ROOT` to resolve the workspace.
+- Stores the last running port in `.saw/utilities/saw.utility.file_browser.json` for reuse.

--- a/saw-workspace/plugins/saw.utility.file_browser/plugin.yaml
+++ b/saw-workspace/plugins/saw.utility.file_browser/plugin.yaml
@@ -1,0 +1,57 @@
+id: "saw.utility.file_browser"
+name: "File Browser (Utility)"
+version: "0.1.0"
+description: "Browse workspace files in a separate Streamlit tab."
+category_path: "utilities"
+meta:
+  human_description: "Launch a Streamlit file browser in a new tab."
+  machine_description: "Utility plugin that starts a Streamlit file explorer and returns a URL."
+  tags: ["utility", "streamlit", "files"]
+entrypoint:
+  file: "wrapper.py"
+  callable: "main"
+environment:
+  python: ">=3.11,<3.13"
+  pip: ["streamlit"]
+inputs: {}
+params:
+  root_path:
+    type: "string"
+    default: ""
+    ui: { label: "Root path (workspace-relative, optional)" }
+outputs:
+  result:
+    type: "object"
+execution:
+  deterministic: false
+  cacheable: false
+side_effects:
+  network: "allowed"
+  disk: "read_only"
+  subprocess: "allowed"
+resources:
+  gpu: "forbidden"
+  threads: 1
+ui:
+  mode: "schema"
+  schema_file: "ui/declarative_ui.yaml"
+  bundle_file: "ui/ui.bundle.js"
+  sandbox: true
+utility:
+  kind: "external_tab"
+  label: "File Browser"
+  description: "Browse workspace files in a new tab."
+  menu_path: ["Utilities", "Files"]
+  icon: "folder"
+  launch:
+    action: "run_plugin"
+    open_target: "new_tab"
+    expect:
+      type: "url"
+      output_path: "result.data.url"
+    app:
+      kind: "streamlit"
+      healthcheck: "/_stcore/health"
+    session:
+      allow_multiple: true
+      reuse_when_open: true

--- a/saw-workspace/plugins/saw.utility.file_browser/streamlit_app.py
+++ b/saw-workspace/plugins/saw.utility.file_browser/streamlit_app.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import quote
+
+import streamlit as st
+
+
+def _resolve_root() -> Path:
+    workspace_root = Path(os.environ.get("SAW_WORKSPACE_ROOT") or Path.cwd()).resolve()
+    root = os.environ.get("SAW_FILE_BROWSER_ROOT") or str(workspace_root)
+    try:
+        return Path(root).resolve()
+    except Exception:
+        return workspace_root
+
+
+def _is_text_file(path: Path) -> bool:
+    return path.suffix.lower() in {".txt", ".md", ".json", ".yaml", ".yml", ".py", ".csv", ".log"}
+
+
+def _is_image_file(path: Path) -> bool:
+    return path.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
+
+
+def _read_preview(path: Path, max_bytes: int = 200_000) -> str:
+    data = path.read_bytes()
+    if len(data) > max_bytes:
+        data = data[:max_bytes]
+    return data.decode("utf-8", errors="replace")
+
+
+def _rel_path(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except Exception:
+        return str(path)
+
+
+st.set_page_config(page_title="SAW File Browser", layout="wide")
+
+root = _resolve_root()
+query = st.query_params
+current_rel = str(query.get("path", ""))
+
+if "current_rel" not in st.session_state:
+    st.session_state.current_rel = current_rel
+
+st.sidebar.header("Workspace")
+root_input = st.sidebar.text_input("Root path", value=str(root))
+
+try:
+    root = Path(root_input).resolve()
+except Exception:
+    root = _resolve_root()
+
+current_dir = root / st.session_state.current_rel if st.session_state.current_rel else root
+if not current_dir.exists() or not current_dir.is_dir():
+    current_dir = root
+    st.session_state.current_rel = ""
+
+st.sidebar.markdown(f"**Current:** `{_rel_path(root, current_dir)}`")
+if st.sidebar.button("Up one level") and current_dir != root:
+    st.session_state.current_rel = _rel_path(root, current_dir.parent)
+    st.rerun()
+
+st.title("File Browser")
+
+cols = st.columns([2, 3])
+with cols[0]:
+    st.subheader("Files & Folders")
+    entries = sorted(current_dir.iterdir(), key=lambda p: (p.is_file(), p.name.lower()))
+    for entry in entries:
+        rel = _rel_path(root, entry)
+        label = f"📄 {entry.name}" if entry.is_file() else f"📁 {entry.name}"
+        if st.button(label, key=f"nav-{rel}"):
+            if entry.is_dir():
+                st.session_state.current_rel = rel
+                st.rerun()
+            else:
+                st.session_state.current_rel = _rel_path(root, entry.parent)
+                st.session_state.selected_file = rel
+                st.rerun()
+
+selected_rel = st.session_state.get("selected_file")
+selected_path = root / selected_rel if selected_rel else None
+
+with cols[1]:
+    st.subheader("Preview")
+    if not selected_path or not selected_path.exists():
+        st.info("Select a file to preview.")
+    else:
+        st.write(f"**{selected_rel}**")
+        preview_url = f"?path={quote(selected_rel)}"
+        st.markdown(
+            f"<a href=\"{preview_url}\" target=\"_blank\">Open preview in new tab</a>",
+            unsafe_allow_html=True,
+        )
+
+        if _is_image_file(selected_path):
+            st.image(str(selected_path))
+        elif _is_text_file(selected_path):
+            st.code(_read_preview(selected_path), language="")
+        else:
+            st.write("Preview not supported. Use download below.")
+
+        with open(selected_path, "rb") as f:
+            st.download_button(
+                label="Download file",
+                data=f,
+                file_name=selected_path.name,
+                mime="application/octet-stream",
+            )

--- a/saw-workspace/plugins/saw.utility.file_browser/ui/declarative_ui.yaml
+++ b/saw-workspace/plugins/saw.utility.file_browser/ui/declarative_ui.yaml
@@ -1,0 +1,10 @@
+version: 1
+sections:
+  - type: builtin
+    component: node_inputs
+  - type: builtin
+    component: node_parameters
+  - type: builtin
+    component: run_panel
+  - type: builtin
+    component: plugin_description

--- a/saw-workspace/plugins/saw.utility.file_browser/wrapper.py
+++ b/saw-workspace/plugins/saw.utility.file_browser/wrapper.py
@@ -1,0 +1,126 @@
+"""SAW Utility: Streamlit File Browser."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _workspace_root(plugin_dir: Path) -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or plugin_dir.parents[2]).resolve()
+
+
+def _choose_free_port(host: str, port_range: tuple[int, int]) -> int:
+    start, end = port_range
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind((host, port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No free port found in range {start}-{end}")
+
+
+def _healthcheck(url: str, timeout_s: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def _state_path(workspace_root: Path, plugin_id: str) -> Path:
+    return workspace_root / ".saw" / "utilities" / f"{plugin_id}.json"
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_state(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _launch_streamlit(app_file: Path, host: str, port: int, env: dict) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_file),
+        "--server.headless",
+        "true",
+        "--server.address",
+        host,
+        "--server.port",
+        str(port),
+        "--server.fileWatcherType",
+        "none",
+    ]
+    subprocess.Popen(
+        cmd,
+        cwd=str(app_file.parent),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def main(inputs: dict, params: dict, context) -> dict:
+    plugin_dir = Path(__file__).resolve().parent
+    workspace_root = _workspace_root(plugin_dir)
+    host = "127.0.0.1"
+    port_range = (8510, 8599)
+
+    params = params or {}
+    root_path = str(params.get("root_path") or "").strip()
+    if root_path:
+        root_path = str((workspace_root / root_path).resolve())
+    else:
+        root_path = str(workspace_root)
+
+    state_path = _state_path(workspace_root, "saw.utility.file_browser")
+    state = _load_state(state_path)
+    url = str(state.get("url") or "")
+
+    if url and _healthcheck(url + "/_stcore/health"):
+        context.log("info", "file_browser:reuse", url=url)
+    else:
+        port = _choose_free_port(host, port_range)
+        url = f"http://{host}:{port}"
+        env = dict(os.environ)
+        env["SAW_WORKSPACE_ROOT"] = str(workspace_root)
+        env["SAW_FILE_BROWSER_ROOT"] = root_path
+        env.setdefault("SAW_API_URL", "http://127.0.0.1:5127")
+
+        app_file = plugin_dir / "streamlit_app.py"
+        _launch_streamlit(app_file, host, port, env)
+
+        # Small delay to let the server boot before returning.
+        time.sleep(0.2)
+        _save_state(state_path, {"url": url, "port": port, "root_path": root_path})
+        context.log("info", "file_browser:launched", url=url, port=port, root_path=root_path)
+
+    return {
+        "result": {
+            "data": {
+                "url": url,
+                "root_path": root_path,
+            },
+            "metadata": {},
+        }
+    }

--- a/saw-workspace/plugins/saw.utility.rag_explorer/README.md
+++ b/saw-workspace/plugins/saw.utility.rag_explorer/README.md
@@ -1,0 +1,7 @@
+# saw.utility.rag_explorer
+
+Utility plugin that launches a Streamlit RAG explorer in a new browser tab.
+
+## Notes
+- Uses `SAW_API_URL` to call `/embed/upsert` and `/search/vector`.
+- Stores the last running port in `.saw/utilities/saw.utility.rag_explorer.json` for reuse.

--- a/saw-workspace/plugins/saw.utility.rag_explorer/plugin.yaml
+++ b/saw-workspace/plugins/saw.utility.rag_explorer/plugin.yaml
@@ -1,0 +1,57 @@
+id: "saw.utility.rag_explorer"
+name: "RAG Explorer (Utility)"
+version: "0.1.0"
+description: "Index content and search embeddings via pgvector in a Streamlit tab."
+category_path: "utilities"
+meta:
+  human_description: "Launch a Streamlit RAG explorer (OpenAI embeddings + pgvector)."
+  machine_description: "Utility plugin that starts a Streamlit RAG UI and returns a URL."
+  tags: ["utility", "streamlit", "rag", "pgvector"]
+entrypoint:
+  file: "wrapper.py"
+  callable: "main"
+environment:
+  python: ">=3.11,<3.13"
+  pip: ["streamlit", "requests"]
+inputs: {}
+params:
+  api_url:
+    type: "string"
+    default: ""
+    ui: { label: "SAW API URL (optional)" }
+outputs:
+  result:
+    type: "object"
+execution:
+  deterministic: false
+  cacheable: false
+side_effects:
+  network: "allowed"
+  disk: "read_only"
+  subprocess: "allowed"
+resources:
+  gpu: "forbidden"
+  threads: 1
+ui:
+  mode: "schema"
+  schema_file: "ui/declarative_ui.yaml"
+  bundle_file: "ui/ui.bundle.js"
+  sandbox: true
+utility:
+  kind: "external_tab"
+  label: "RAG Explorer"
+  description: "Index documents + search embeddings via pgvector."
+  menu_path: ["Utilities", "RAG"]
+  icon: "sparkles"
+  launch:
+    action: "run_plugin"
+    open_target: "new_tab"
+    expect:
+      type: "url"
+      output_path: "result.data.url"
+    app:
+      kind: "streamlit"
+      healthcheck: "/_stcore/health"
+    session:
+      allow_multiple: true
+      reuse_when_open: true

--- a/saw-workspace/plugins/saw.utility.rag_explorer/streamlit_app.py
+++ b/saw-workspace/plugins/saw.utility.rag_explorer/streamlit_app.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import requests
+import streamlit as st
+
+
+def _api_url() -> str:
+    return os.environ.get("SAW_API_URL") or "http://127.0.0.1:5127"
+
+
+def _workspace_root() -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or Path.cwd()).resolve()
+
+
+def _read_file(rel_path: str) -> str:
+    root = _workspace_root()
+    path = (root / rel_path).resolve()
+    if not str(path).startswith(str(root)):
+        raise ValueError("Path outside workspace")
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+st.set_page_config(page_title="SAW RAG Explorer", layout="wide")
+st.title("RAG Explorer")
+
+api_url = st.sidebar.text_input("SAW API URL", value=_api_url())
+model = st.sidebar.text_input("Embedding model", value="")
+chunk_max = st.sidebar.number_input("Chunk max chars", min_value=500, max_value=8000, value=4000, step=250)
+chunk_overlap = st.sidebar.number_input("Chunk overlap", min_value=0, max_value=2000, value=300, step=50)
+
+st.subheader("Index content")
+uri = st.text_input("Document URI", value="")
+source_mode = st.radio("Content source", ["Text", "Workspace file"], horizontal=True)
+content_text = ""
+
+if source_mode == "Workspace file":
+    rel_path = st.text_input("Workspace-relative file path", value="")
+    if rel_path:
+        try:
+            content_text = _read_file(rel_path)
+            st.caption(f"Loaded {len(content_text)} characters from {rel_path}")
+        except Exception as exc:
+            st.error(f"Failed to read file: {exc}")
+else:
+    content_text = st.text_area("Content", height=200)
+
+if st.button("Index document"):
+    if not uri.strip():
+        st.error("Provide a document URI.")
+    elif not content_text.strip():
+        st.error("Provide document content.")
+    else:
+        payload = {
+            "uri": uri.strip(),
+            "doc_type": "rag_doc",
+            "content_text": content_text,
+            "metadata_json": {},
+            "model": model or None,
+            "chunk_max_chars": int(chunk_max),
+            "chunk_overlap_chars": int(chunk_overlap),
+        }
+        try:
+            resp = requests.post(f"{api_url.rstrip('/')}/embed/upsert", json=payload, timeout=60)
+            if resp.ok:
+                st.success(resp.json())
+            else:
+                st.error(resp.text)
+        except Exception as exc:
+            st.error(f"Request failed: {exc}")
+
+st.markdown("---")
+
+st.subheader("Search embeddings")
+query = st.text_input("Query")
+top_k = st.number_input("Top K", min_value=1, max_value=25, value=8, step=1)
+
+if st.button("Search"):
+    if not query.strip():
+        st.error("Provide a query.")
+    else:
+        payload = {"query": query.strip(), "top_k": int(top_k), "model": model or None}
+        try:
+            resp = requests.post(f"{api_url.rstrip('/')}/search/vector", json=payload, timeout=60)
+            if resp.ok:
+                data = resp.json()
+                hits = data.get("hits") or []
+                st.caption(f"Model: {data.get('model')} • Hits: {len(hits)}")
+                for hit in hits:
+                    st.markdown(f"**{hit.get('uri')}** (distance: {hit.get('distance')})")
+                    if hit.get("content_text"):
+                        st.code(hit.get("content_text"), language="")
+                    if hit.get("metadata_json"):
+                        st.json(hit.get("metadata_json"))
+                    st.markdown("---")
+            else:
+                st.error(resp.text)
+        except Exception as exc:
+            st.error(f"Request failed: {exc}")

--- a/saw-workspace/plugins/saw.utility.rag_explorer/ui/declarative_ui.yaml
+++ b/saw-workspace/plugins/saw.utility.rag_explorer/ui/declarative_ui.yaml
@@ -1,0 +1,10 @@
+version: 1
+sections:
+  - type: builtin
+    component: node_inputs
+  - type: builtin
+    component: node_parameters
+  - type: builtin
+    component: run_panel
+  - type: builtin
+    component: plugin_description

--- a/saw-workspace/plugins/saw.utility.rag_explorer/wrapper.py
+++ b/saw-workspace/plugins/saw.utility.rag_explorer/wrapper.py
@@ -1,0 +1,119 @@
+"""SAW Utility: Streamlit RAG Explorer."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _workspace_root(plugin_dir: Path) -> Path:
+    return Path(os.environ.get("SAW_WORKSPACE_ROOT") or plugin_dir.parents[2]).resolve()
+
+
+def _choose_free_port(host: str, port_range: tuple[int, int]) -> int:
+    start, end = port_range
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind((host, port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No free port found in range {start}-{end}")
+
+
+def _healthcheck(url: str, timeout_s: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def _state_path(workspace_root: Path, plugin_id: str) -> Path:
+    return workspace_root / ".saw" / "utilities" / f"{plugin_id}.json"
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_state(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _launch_streamlit(app_file: Path, host: str, port: int, env: dict) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_file),
+        "--server.headless",
+        "true",
+        "--server.address",
+        host,
+        "--server.port",
+        str(port),
+        "--server.fileWatcherType",
+        "none",
+    ]
+    subprocess.Popen(
+        cmd,
+        cwd=str(app_file.parent),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def main(inputs: dict, params: dict, context) -> dict:
+    plugin_dir = Path(__file__).resolve().parent
+    workspace_root = _workspace_root(plugin_dir)
+    host = "127.0.0.1"
+    port_range = (8690, 8779)
+
+    params = params or {}
+    api_url = str(params.get("api_url") or "").strip() or os.environ.get("SAW_API_URL") or "http://127.0.0.1:5127"
+
+    state_path = _state_path(workspace_root, "saw.utility.rag_explorer")
+    state = _load_state(state_path)
+    url = str(state.get("url") or "")
+
+    if url and _healthcheck(url + "/_stcore/health"):
+        context.log("info", "rag_explorer:reuse", url=url)
+    else:
+        port = _choose_free_port(host, port_range)
+        url = f"http://{host}:{port}"
+        env = dict(os.environ)
+        env["SAW_WORKSPACE_ROOT"] = str(workspace_root)
+        env["SAW_API_URL"] = api_url
+
+        app_file = plugin_dir / "streamlit_app.py"
+        _launch_streamlit(app_file, host, port, env)
+
+        time.sleep(0.2)
+        _save_state(state_path, {"url": url, "port": port, "api_url": api_url})
+        context.log("info", "rag_explorer:launched", url=url, port=port, api_url=api_url)
+
+    return {
+        "result": {
+            "data": {
+                "url": url,
+            },
+            "metadata": {},
+        }
+    }

--- a/services/saw_api/app/main.py
+++ b/services/saw_api/app/main.py
@@ -691,6 +691,7 @@ class PluginListItem(BaseModel):
     origin: Literal["stock", "dev"] = "dev"
     integrity: dict[str, Any] | None = None
     ui: dict[str, Any] | None = None
+    utility: dict[str, Any] | None = None
     meta: dict[str, Any] | None = None
     inputs: list[dict[str, Any]] = Field(default_factory=list)
     outputs: list[dict[str, Any]] = Field(default_factory=list)
@@ -774,6 +775,7 @@ def plugins_list() -> PluginListResponse:
                     origin=origin,
                     integrity=integrity,
                     ui=(m.ui.model_dump() if getattr(m, "ui", None) is not None else None),
+                    utility=(m.utility.model_dump() if getattr(m, "utility", None) is not None else None),
                     meta=(m.meta.model_dump() if getattr(m, "meta", None) is not None else None),
                     inputs=inputs,
                     outputs=outputs,

--- a/services/saw_api/app/plugins_runtime.py
+++ b/services/saw_api/app/plugins_runtime.py
@@ -78,6 +78,38 @@ class PluginMeta(BaseModel):
     docs: dict[str, str] | None = None
 
 
+class UtilityLaunchExpect(BaseModel):
+    type: Literal["url"] = "url"
+    output_path: str = "result.data.url"
+
+
+class UtilityLaunchApp(BaseModel):
+    kind: Literal["streamlit", "http"] = "streamlit"
+    healthcheck: str | None = None
+
+
+class UtilityLaunchSession(BaseModel):
+    allow_multiple: bool = True
+    reuse_when_open: bool = True
+
+
+class UtilityLaunchSpec(BaseModel):
+    action: Literal["run_plugin"] = "run_plugin"
+    open_target: Literal["new_tab"] = "new_tab"
+    expect: UtilityLaunchExpect | None = None
+    app: UtilityLaunchApp | None = None
+    session: UtilityLaunchSession | None = None
+
+
+class UtilitySpec(BaseModel):
+    kind: Literal["external_tab"] = "external_tab"
+    label: str | None = None
+    description: str | None = None
+    menu_path: list[str] = Field(default_factory=list)
+    icon: str | None = None
+    launch: UtilityLaunchSpec | None = None
+
+
 class PluginManifest(BaseModel):
     id: str
     name: str
@@ -95,6 +127,7 @@ class PluginManifest(BaseModel):
     side_effects: SideEffectsSpec
     resources: ResourcesSpec
     ui: PluginUiSpec | None = None
+    utility: UtilitySpec | None = None
     meta: PluginMeta | None = None
 
 

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -11,6 +11,20 @@ export type WorkspacePluginListItem = {
   origin?: 'stock' | 'dev'
   integrity?: { expected: string; actual: string; restored: boolean } | null
   ui?: { mode?: 'schema' | 'bundle'; schema_file?: string; bundle_file?: string; sandbox?: boolean } | null
+  utility?: {
+    kind?: 'external_tab'
+    label?: string
+    description?: string
+    menu_path?: string[]
+    icon?: string
+    launch?: {
+      action?: 'run_plugin'
+      open_target?: 'new_tab'
+      expect?: { type?: 'url'; output_path?: string }
+      app?: { kind?: 'streamlit' | 'http'; healthcheck?: string }
+      session?: { allow_multiple?: boolean; reuse_when_open?: boolean }
+    }
+  } | null
   meta?: Record<string, any> | null
   inputs?: Array<{ id: string; name: string; type: string }>
   outputs?: Array<{ id: string; name: string; type: string }>
@@ -58,8 +72,8 @@ export async function fetchWorkspacePlugins(apiBase = 'http://127.0.0.1:5127'): 
       sourcePaths,
       locked: Boolean(p.locked),
       origin: p.origin === 'stock' ? 'stock' : 'dev',
-        integrity: p.integrity ?? null,
-        meta: (p.meta && typeof p.meta === 'object') ? p.meta : null,
+      integrity: p.integrity ?? null,
+      meta: p.meta && typeof p.meta === 'object' ? p.meta : null,
       ui:
         p.ui && (p.ui.mode === 'schema' || p.ui.mode === 'bundle')
           ? {
@@ -69,11 +83,63 @@ export async function fetchWorkspacePlugins(apiBase = 'http://127.0.0.1:5127'): 
               sandbox: typeof p.ui.sandbox === 'boolean' ? p.ui.sandbox : undefined,
             }
           : null,
+      utility:
+        p.utility && typeof p.utility === 'object'
+          ? {
+              kind: p.utility.kind === 'external_tab' ? 'external_tab' : undefined,
+              label: typeof p.utility.label === 'string' ? p.utility.label : undefined,
+              description: typeof p.utility.description === 'string' ? p.utility.description : undefined,
+              menu_path: Array.isArray(p.utility.menu_path) ? p.utility.menu_path.map(String) : undefined,
+              icon: typeof p.utility.icon === 'string' ? p.utility.icon : undefined,
+              launch:
+                p.utility.launch && typeof p.utility.launch === 'object'
+                  ? {
+                      action: p.utility.launch.action === 'run_plugin' ? 'run_plugin' : undefined,
+                      open_target: p.utility.launch.open_target === 'new_tab' ? 'new_tab' : undefined,
+                      expect:
+                        p.utility.launch.expect && typeof p.utility.launch.expect === 'object'
+                          ? {
+                              type: p.utility.launch.expect.type === 'url' ? 'url' : undefined,
+                              output_path:
+                                typeof p.utility.launch.expect.output_path === 'string'
+                                  ? p.utility.launch.expect.output_path
+                                  : undefined,
+                            }
+                          : undefined,
+                      app:
+                        p.utility.launch.app && typeof p.utility.launch.app === 'object'
+                          ? {
+                              kind:
+                                p.utility.launch.app.kind === 'streamlit' || p.utility.launch.app.kind === 'http'
+                                  ? p.utility.launch.app.kind
+                                  : undefined,
+                              healthcheck:
+                                typeof p.utility.launch.app.healthcheck === 'string'
+                                  ? p.utility.launch.app.healthcheck
+                                  : undefined,
+                            }
+                          : undefined,
+                      session:
+                        p.utility.launch.session && typeof p.utility.launch.session === 'object'
+                          ? {
+                              allow_multiple:
+                                typeof p.utility.launch.session.allow_multiple === 'boolean'
+                                  ? p.utility.launch.session.allow_multiple
+                                  : undefined,
+                              reuse_when_open:
+                                typeof p.utility.launch.session.reuse_when_open === 'boolean'
+                                  ? p.utility.launch.session.reuse_when_open
+                                  : undefined,
+                            }
+                          : undefined,
+                    }
+                  : undefined,
+            }
+          : null,
       inputs: toPorts(p.inputs),
       outputs: toPorts(p.outputs),
       parameters: toParams(p.parameters),
     } satisfies PluginDefinition
   })
 }
-
 

--- a/src/types/saw.ts
+++ b/src/types/saw.ts
@@ -25,6 +25,38 @@ export type PluginUiConfig = {
   sandbox?: boolean
 }
 
+export type UtilityLaunchExpect = {
+  type: 'url'
+  output_path: string
+}
+
+export type UtilityLaunchApp = {
+  kind?: 'streamlit' | 'http'
+  healthcheck?: string
+}
+
+export type UtilityLaunchSession = {
+  allow_multiple?: boolean
+  reuse_when_open?: boolean
+}
+
+export type UtilityLaunchSpec = {
+  action?: 'run_plugin'
+  open_target?: 'new_tab'
+  expect?: UtilityLaunchExpect
+  app?: UtilityLaunchApp
+  session?: UtilityLaunchSession
+}
+
+export type UtilitySpec = {
+  kind?: 'external_tab'
+  label?: string
+  description?: string
+  menu_path?: string[]
+  icon?: string
+  launch?: UtilityLaunchSpec
+}
+
 export type PluginDefinition = {
   id: string
   name: string
@@ -47,6 +79,7 @@ export type PluginDefinition = {
   origin?: 'stock' | 'dev'
   integrity?: { expected: string; actual: string; restored: boolean } | null
   ui?: PluginUiConfig | null
+  utility?: UtilitySpec | null
   meta?: Record<string, any> | null
   inputs: Port[]
   outputs: Port[]
@@ -116,4 +149,3 @@ export type PluginNodeData = {
 }
 
 export type PluginNode = Node<PluginNodeData, 'pluginNode'>
-


### PR DESCRIPTION
### Motivation

- Provide a small, supported mechanism for launching full-page utility UIs (Streamlit/HTTP) in new browser tabs while keeping `plugin.yaml` as the single source of truth. 
- Surface workspace-declared utilities in the frontend so operators can open separate tools (file browser, DB explorer, RAG, API health) without changing plugin execution semantics. 
- Reuse existing plugin discovery + execution flow and require wrappers to return a URL to the launched app. 
- Clarify the machine spec `output_path` guidance to point at the returned URL (`result.data.url`).

### Description

- Backend: added `utility` manifest models in `services/saw_api/app/plugins_runtime.py` and included `utility` in the `/plugins/list` payload returned by `services/saw_api/app/main.py`.  
- Frontend/types: extended TS types with `UtilitySpec` / launch shapes in `src/types/saw.ts`, extended workspace plugin mapping in `src/plugins/workspace.ts`, and added a `Utilities` menu to the top bar in `src/components/TopBar.tsx` that calls the existing plugin execute endpoint and opens the returned URL.  
- Utilities: implemented four simple Streamlit utilities under `saw-workspace/plugins/` (each with `plugin.yaml`, `wrapper.py`, `streamlit_app.py`, `ui/declarative_ui.yaml`, and README): `saw.utility.file_browser`, `saw.utility.db_browser`, `saw.utility.rag_explorer`, and `saw.utility.api_health_explorer`. Each wrapper starts/detaches a Streamlit process, persists last-run port under `.saw/utilities/`, healthchecks for reuse, and returns `result.data.url`.  
- Docs/spec: updated `saw-workspace/machine-specs/utility_external_tabs_spec.yaml` to use `result.data.url`, added `utility` note to `saw-workspace/human-context/PLUGIN_SCHEMA.md`, and recorded the change in `saw-workspace/machine-context/START_HERE.md` and `saw-workspace/human-context/Directory.md`.

### Testing

- Started the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and confirmed Vite came up successfully.  
- Ran a Playwright script that opened `http://127.0.0.1:5173/` and produced a screenshot of the top bar / Utilities menu (`artifacts/utilities-menu.png`).  
- Observed Vite proxy errors contacting the SAW API (expected because the SAW API backend was not running in the test environment), so plugin execution and Streamlit launches were not exercised end-to-end.  
- No automated unit tests were added; no backend plugin-run integration tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698687a3dc248328bd7f35eb1fcce08f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new manifest surface and UI entrypoint that can execute plugins and open arbitrary returned URLs, plus introduces subprocess-spawning Streamlit wrappers; failures or misconfigurations could impact local runtime behavior but scope is largely additive.
> 
> **Overview**
> Adds first-class *utility plugin* metadata to plugin manifests and threads it through the system, so `/plugins/list` now includes a `utility` object parsed/validated by the backend.
> 
> Frontend consumes this new `utility` field in catalog typing/mapping and adds a **Utilities** dropdown in `TopBar` that executes the selected plugin and opens the returned `result.data.url` in a new browser tab (logging failures to the errors/logs panels).
> 
> Introduces four new Streamlit-based utility plugins (`file_browser`, `db_browser`, `rag_explorer`, `api_health_explorer`) whose wrappers spawn/reuse a detached Streamlit server on a free port, persist last-used state under `.saw/utilities/`, and return the launch URL; accompanying docs/specs are updated to document the `utility` schema and `output_path` convention.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2627257a6386ce377ac17bc6a808cbf0e0022e21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->